### PR TITLE
ユーザ新規登録ビュー、ログインビュー

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import "modules/new";
 @import "modules/buyscreen";
 @import "modules/show";
+@import "modules/step1";

--- a/app/assets/stylesheets/modules/_step1.scss
+++ b/app/assets/stylesheets/modules/_step1.scss
@@ -1,0 +1,101 @@
+.l-single-container{
+  text-align: center;
+  height: 59px;
+  padding: 18px;
+  font-size: 18px;
+  border-bottom: solid 1px #b4d7ee9d;
+  font-weight: bold;
+}
+.field{
+  text-align: center;
+  .field-ls{
+    display: inline-flex;
+    margin-bottom: 5px;
+    margin-top: 16px;
+    
+    
+    .field-label{
+      font-weight: 600;
+      font-size: 14px;
+      margin-right: 10px;
+      
+    }
+    span{
+      background-color: red;
+      font-size: 14px;
+      color: white;
+      border-radius: 2px;
+    }
+  }
+  .field-input{
+    height: 48px;
+    input{
+      height: 48px;
+      width: 343px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+    }
+    p{
+      color: #888888;
+     }
+     select{
+      height: 48px;
+      width: 15%;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      margin-right: 20px;
+     }
+  }
+
+}
+.actions{
+  margin-top: 30px;
+  margin-bottom: 20px;
+  height: 50px;
+  text-align: center;
+  input{
+    width: 343px;
+    height: 49px;
+    background-color: rgb(104, 196, 224);
+    color: white;
+    border-radius: 4px;
+  }
+}
+//ログイン機能　newhtml.haml
+.account-page__inner--left.account-page__header{
+  text-align: center;
+  margin-bottom: 15px;
+  margin-top: 15px;
+  height: 100%;
+  width: 100%;
+
+
+  .btn{
+    font-size: 20px;
+    width: 300px;
+    height: 49px;
+    text-decoration: none;
+    background-color: rgb(106, 196, 231);
+    color:white;
+  }
+}
+.account-page__inner--right.user-form{
+  .field{
+    margin-bottom: 45px;
+    .field-input{
+      margin-bottom: 30px;
+    }
+  .actions{
+
+    height: 50px;
+    text-align: center;
+    input{
+      width: 343px;
+      height: 49px;
+      background-color: rgb(104, 196, 224);
+      color: white;
+      border-radius: 4px;
+    }
+  }
+}
+}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,8 +1,7 @@
 #account-page.account-page
   .account-page__inner.clearfix
     .account-page__inner--left.account-page__header
-      %h2 Log in
-      %h5 登録しているユーザーでログイン
+      %h5 アカウントをお持ちでない方はこちら
       = render "devise/shared/links"
     .account-page__inner--right.user-form
       = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
@@ -10,12 +9,12 @@
           .field-label
             = f.label :email
           .field-input
-            = f.email_field :email, autofocus: true
+            = f.email_field :email, autofocus: true, placeholder: "メールアドレス"
           .field
             .field-label
               = f.label :password
-              %i (英数字8文字以上)
+              %i (英数字7文字以上)
             .field-input
-              = f.password_field :password, autocomplete: "off"
+              = f.password_field :password, autocomplete: "off", placeholder: "パスワード"
           .actions
-            = f.submit "Log in", class: 'btn'
+            = f.submit "ログイン", class: 'btn'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,5 +2,5 @@
   = link_to "Log in", new_session_path(resource_name), class: 'btn'
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name), class: 'btn'
+  = link_to "新規会員登録", new_registration_path(resource_name), class: 'btn'
   %br/

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -2,24 +2,36 @@
 
   = hidden_field_tag :current_step, 'step1' 
   = render partial: 'error-step1', locals: {user: @user} #ニックネームのエラー文のみ表示したい場合
+
+  .l-single-container
+    %h2 会員情報入力
   .field
-    .field-label
-      = f.label :nickname,"ニックネーム"
+    .field-ls
+      .field-label
+        = f.label :nickname,"ニックネーム"
+      %span 必須
     .field-input
-      = f.text_field :nickname, autofocus: true
+      = f.text_field :nickname, autofocus: true, placeholder:"例)フリマ太郎"
   .field
-    .field-label
-      = f.label :email
+    .field-ls
+      .field-label
+        = f.label :email
+      %span 必須
     .field-input
-      = f.email_field :email
+      = f.email_field :email, placeholder:"pc・携帯どちらでも可"
   .field
-    .field-label
-      = f.label :password,"パスワードを英数字で7文字以上入力してください"
+    .field-ls
+      .field-label
+        = f.label :password,"パスワード"
+      %span 必須
     .field-input
-      = f.password_field :password, autocomplete: "off"
+      = f.password_field :password, autocomplete: "off", placeholder: "7文字以上の半角英数字"
   .field
-    .field-label
-      = f.label :password_confirmation
+    .field-ls
+      .field-label
+        = f.label :password_confirmation, "パスワード確認"
+      %span 必須
     .field-input
-      = f.password_field :password_confirmation, autocomplete: "off"
-  = f.submit '次へ進む'
+      = f.password_field :password_confirmation, autocomplete: "off",placeholder: "確認のためもう一度入力してください"
+  .actions
+    = f.submit '次へ進む', class: "submit-btn"

--- a/app/views/signup/step2.html.haml
+++ b/app/views/signup/step2.html.haml
@@ -1,30 +1,44 @@
 = form_for @user, url: step3_signup_index_path do |f|
   = hidden_field_tag :current_step, 'step2'
   = render partial: 'error-step2', locals: {user: @user} #ニックネームのエラー文のみ表示したい場合
+
+  .l-single-container
+    %h2 会員情報入力
   .field
-    .field-label
-      = f.label :family_name, "名字"
+    .field-ls
+      .field-label
+        = f.label :family_name, "名字"
+      %span 必須
     .field-input
-      = f.text_field :family_name, autofocus: true
+      = f.text_field :family_name, autofocus: true, placeholder:"例）山田"
   .field
-    .field-label
-      = f.label :first_name, "名前"
+    .field-ls
+      .field-label
+        = f.label :first_name, "名前"
+      %span 必須
     .field-input
-      = f.text_field :first_name, autofocus: true
-    %p.furigana ふりがなで入力してください
+      = f.text_field :first_name, autofocus: true, placeholder:"例）太郎"
+    %p.furigana ＊ふりがなで入力してください
     .field
-      .field-label
-        = f.label :furigana_family_name, "名字"
+      .field-ls
+        .field-label
+          = f.label :furigana_family_name, "名字"
+        %span 必須
       .field-input
-        = f.text_field :furigana_family_name, autofocus: true
+        = f.text_field :furigana_family_name, autofocus: true, placeholder:"例）やまだ"
     .field
-      .field-label
-        = f.label :furigana_first_name, "名前"
+      .field-ls
+        .field-label
+          = f.label :furigana_first_name, "名前"
+        %span 必須
       .field-input
-        = f.text_field :furigana_first_name, autofocus: true
+        = f.text_field :furigana_first_name, autofocus: true, placeholder:"例）たろう"
     .field
-      .field-label
-        = f.label :birthday, "生年月日を入力してくだい"
+      .field-ls
+        .field-label
+          = f.label :birthday, "生年月日を入力してくだい"
+        %span 必須
       .field-input
         = f.date_select :birthday, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
-  = f.submit '次へ進む'
+  .actions       
+    = f.submit '次へ進む'

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -2,51 +2,71 @@
   = hidden_field_tag :current_step, 'step3'
   = render partial: 'error-step3', locals: {address: @user} #ニックネームのエラー文のみ表示したい場合
   = f.fields_for :address do |a|
-  
+    .l-single-container
+      %h2 会員情報入力
     .field
-      .field-label
-        = a.label :family_name, "名字"
+      .field-ls
+        .field-label
+          = a.label :family_name, "名字"
+        %span 必須
       .field-input
-        = a.text_field :family_name, autofocus: true
+        = a.text_field :family_name, autofocus: true, placeholder:"例）山田"
     .field
-      .field-label
-        = a.label :first_name, "名前"
+      .field-ls
+        .field-label
+          = a.label :first_name, "名前"
+        %span 必須
       .field-input
-        = a.text_field :first_name, autofocus: true
+        = a.text_field :first_name, autofocus: true, placeholder:"例）太郎"
       %p.furigana ふりがなで入力してください
     .field
-      .field-label
-        = a.label :furigana_family_name, "名字"
+      .field-ls
+        .field-label
+          = a.label :furigana_family_name, "名字"
+        %span 必須
       .field-input
-        = a.text_field :furigana_family_name, autofocus: true
+        = a.text_field :furigana_family_name, autofocus: true, placeholder:"例）やまだ"
     .field
-      .field-label
-        = a.label :furigana_first_name, "名前"
+      .field-ls
+        .field-label
+          = a.label :furigana_first_name, "名前"
+        %span 必須
       .field-input
-        = a.text_field :furigana_first_name, autofocus: true
+        = a.text_field :furigana_first_name, autofocus: true, placeholder:"例）たろう"
     .field
-      .field-label
-        = a.label :zipcode, "郵便番号"
+      .field-ls
+        .field-label
+          = a.label :zipcode, "郵便番号"
+        %span 必須
       .field-input
-        = a.text_field :zipcode, autofocus: true
+        = a.text_field :zipcode, autofocus: true, placeholder:"例）000-0000"
     .field
-      .field-label
-        = a.label :prefecture, "都道府県"
+      .field-ls
+        .field-label
+          = a.label :prefecture, "都道府県"
+        %span 必須
       .field-input
         = a.collection_select :prefecture, Prefecture.all, :id, :name, prompt: "選択してください"
     .field
-      .field-label
-        = a.label :city, "市区町村"
+      .field-ls
+        .field-label
+          = a.label :city, "市区町村"
+        %span 必須
       .field-input
-        = a.text_field :city
+        = a.text_field :city, placeholder:"例）○○市○○区"
     .field
-      .field-label
-        = a.label :street, "番地"
+      .field-ls
+        .field-label
+          = a.label :street, "番地"
+        %span 必須
       .field-input
-        = a.text_field :street
+        = a.text_field :street, placeholder:"例）1-1-1"
     .field
-      .field-label
-        = a.label :tell, "電話番号もしくは携帯電話番号（ハイフンなし）"
+      .field-ls
+        .field-label
+          = a.label :tell, "電話番号もしくは携帯電話番号（ハイフンなし）"
+        %span 必須
       .field-input
-        = a.text_field :tell
-  = f.submit '登録を完了する'
+        = a.text_field :tell, placeholder:"例）0001112222"
+  .actions 
+    = f.submit '登録を完了する'

--- a/db/migrate/20200605084328_create_addresses.rb
+++ b/db/migrate/20200605084328_create_addresses.rb
@@ -15,7 +15,6 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
 
       t.timestamps
 
-      add_index :users, :nickname,             unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,15 +29,6 @@ ActiveRecord::Schema.define(version: 2020_06_05_193931) do
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
-  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "customer_id", null: false
-    t.string "card_id", null: false
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_cards_on_user_id"
-  end
-  
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -85,5 +76,4 @@ ActiveRecord::Schema.define(version: 2020_06_05_193931) do
   end
 
   add_foreign_key "addresses", "users"
-  add_foreign_key "cards", "users"
 end


### PR DESCRIPTION
### WHY
新規登録画面とログイン画面のビューをわかりやすく表示する

###WHAT
STEP1~3までのビューを作成した
必須と横に赤くつけることで入力するべき場所が視覚的にわかりやすくなりました
placeholder:を書くことによって例などを表示しました

![](https://i.gyazo.com/f9ddd3e449341dc0cef2748882490e14.png)

![](https://i.gyazo.com/8ac52a39c0eead9a3e1a73ab8d0e8338.png)
